### PR TITLE
fix: 修复 IDM 无法下载百度网盘链接

### DIFF
--- a/（改）网盘直链下载助手.user.js
+++ b/（改）网盘直链下载助手.user.js
@@ -815,7 +815,7 @@
 				format(122, 4), // 122: 代理
 			];
 
-			let data = `MSG#${seq}#13#1#10241:${seq + 1000}:0:${time}:0:1:1:${filesize}:0,${fields.join(",")};`;
+			let data = `MSG#${seq}#13#1#10241:${seq + 1000}:0:${time}:0:1:2:${filesize}:0,${fields.join(",")};`;
 			try {
 				let res = await base.post(url, data, {}, "text");
 				// 这里返回的是请求的响应文本，不是响应对象，所以res?.status === 200 && res?.statusText === "IDM"不能使用
@@ -8166,4 +8166,5 @@ a.downloadSubtitle:disabled, button.downloadSubtitle:disabled{background-color:$
 		}
 		return charArray.join("");
 	}
+
 })($ ?? jQuery);


### PR DESCRIPTION
主动向IDM请求下载，而不是让IDM来监听

请求体的构建仅对IDM协议进行部分逆向所得，并不一定试用于其他下载请求

目前测试百度网盘可以正常下载了

<img width="1755" height="455" alt="image" src="https://github.com/user-attachments/assets/11827dc3-6f55-4ea8-a012-fbcd5865d7c2" />
我使用的IDM版本是6.42 Build58，不确定其他版本协议是否一样，不过这部分一般不会做更改，多半是兼容的。