### PR TITLE
修复：迅雷云盘不显示 “下载助手”

### DIFF
--- a/（改）网盘直链下载助手.user.js
+++ b/（改）网盘直链下载助手.user.js
@@ -358,8 +358,8 @@
 				getCaptchaToken: "https://xluser-ssl.xunlei.com/v1/shield/captcha/init",
 			},
 			mount: {
-				home: `[class^="FileMenu__menu--"]`,
-				share: `[class^="Share__batchActionBox--"]`
+			    home: `[class*="FileMenu__menus--"], [class*="FileMenu__menu--"]`,
+			    share: `[class^="Share__batchActionBox--"]`
 			},
 			dom: {
 				enhance: `+<br/>此方式可以自动设置文件名，然后下载。<br/>此方式的下载请求<b>不会</b>被 IDM 捕获。`,


### PR DESCRIPTION
## 问题
迅雷云盘新版页面将主页文件菜单容器的类名前缀从 `FileMenu__menu--` 调整为了 `FileMenu__menus--`
LinkSwift 当前使用以下选择器挂载下载助手按钮：`[class^="FileMenu__menu--"]`
因此无法匹配新版菜单容器，导致迅雷云盘主页不显示“下载助手”或“点我点亮”按钮。

## 修改
同时匹配新旧两个类名前缀：
`[class*="FileMenu__menus--"], [class*="FileMenu__menu--"]`
使用部分匹配，避免依赖 CSS Modules 构建生成的随机后缀。

## 测试
- [x] 在迅雷云盘主页确认新版工具栏类名为 `FileMenu__menus--HFKwO`
- [x] 修改后能够匹配主页工具栏容器
- [x] 修改后“下载助手”按钮正常显示
- [x] 保留对旧版 `FileMenu__menu--` 类名前缀的兼容

## 相关问题

#429 #455