### PR TITLE
feat(quark): 支持网盘文件夹递归下载及 Aria2 子目录推送

### DIFF
--- a/QUARK-RECURSIVE.md
+++ b/QUARK-RECURSIVE.md
@@ -1,0 +1,40 @@
+# Quark Recursive Downloads
+
+This branch adds recursive file collection for folders selected in the user's
+Quark drive, including folders saved from a share. Share pages retain their
+existing file-only behavior.
+
+In LinkSwift's Aria2 settings, set the download directory to an absolute path
+on the downloader machine (for example `/home/user/Downloads`). Select a
+folder in the Quark drive, choose Aria2 download, then push the generated tasks.
+The selected folder and its descendants are preserved below that directory.
+Other download modes collect files but do not preserve the directory tree.
+Empty directories are not created.
+
+The implementation lists `/1/clouddrive/file/sort` in pages of 100, traverses
+subfolders, deduplicates by file ID and fails on listing errors. Download URL
+responses are matched back to their file IDs to preserve their relative paths.
+Aria2 tasks receive the original filename, headers and a per-file directory.
+
+## Validation
+
+Run:
+
+```sh
+node --test tests/quark-recursive.test.cjs
+node --check '（改）网盘直链下载助手.user.js'
+npx --no-install eslint '（改）网盘直链下载助手.user.js' tests/quark-recursive.test.cjs
+```
+
+- Six automated tests cover nested folders, pagination, duplicate selections,
+  same-name files, empty folders, direct files, failed listing, path traversal,
+  RPC forwarding and reordered download responses.
+- A live Ghost Downloader 4.3.7 RPC test created `Root/Child/check.txt` with
+  matching contents under a temporary test directory.
+- The user installed the modified script and confirmed the Quark workflow
+  works in their real account. The exact folder depth and file count were not
+  reported; pagination and same-name files are covered by automated tests.
+- Existing userscript lint warnings about unused `items` and `token` remain.
+
+Directory API reference:
+https://github.com/OpenListTeam/OpenList/blob/main/drivers/quark_uc/util.go

--- a/tests/quark-recursive.test.cjs
+++ b/tests/quark-recursive.test.cjs
@@ -1,0 +1,96 @@
+/* global __dirname */
+const { test } = require('node:test');
+const { URL } = require('node:url');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const path = require('node:path');
+
+const source = fs.readFileSync(path.join(__dirname, '../（改）网盘直链下载助手.user.js'), 'utf8').replace(/\r\n/g, '\n');
+const quark = source.slice(source.indexOf('const $quark = {'));
+
+function setup(get) {
+ const context = { URL, document: { cookie: '' }, config: { $quark: { api: { getLink: 'https://drive-pc.quark.cn/1/clouddrive/file/download?pr=ucpro', ua: { downloadLink: 'test' } } } }, base: { get, sleep: async () => {} } };
+ // Extract the method without executing the userscript or accessing an account.
+ const end = quark.indexOf('\n\t\t},', quark.indexOf('async collectFiles(')) + '\n\t\t}'.length;
+ return vm.runInNewContext('({' + quark.slice(quark.indexOf('async collectFiles('), end) + '})', context);
+}
+
+test('nested folders, pagination, duplicate selections and same-name files', async () => {
+ const calls = [];
+ const root = { fid: 'root', file: false, file_name: 'Root' };
+ const child = { fid: 'child', file: false, file_name: 'Child' };
+ const first = Array.from({ length: 99 }, (_, i) => ({ fid: 'f' + i, file: true, file_name: 'file' + i }));
+ first.push(child);
+ const api = setup(async address => {
+  const url = new URL(address);
+  const dir = url.searchParams.get('pdir_fid');
+  const page = url.searchParams.get('_page');
+  calls.push([dir, page]);
+  const list = dir === 'child' ? [{ fid: 'nested', file: true, file_name: 'file0' }] : page === '1' ? first : [{ fid: 'last', file: true, file_name: 'last' }];
+  return { code: 0, data: { list } };
+ });
+ const files = await api.collectFiles([root, child]);
+ assert.equal(files.length, 101);
+ assert.equal(files.find(f => f.fid === 'nested').relativeDirectory, 'Root/Child');
+ assert.equal(files.find(f => f.fid === 'f0').relativeDirectory, 'Root');
+ assert.deepEqual(calls, [['root', '1'], ['child', '1'], ['root', '2']]);
+});
+
+test('empty folders and direct files', async () => {
+ const api = setup(async () => ({ code: 0, data: { list: [] } }));
+ assert.equal((await api.collectFiles([{ fid: 'empty', file: false, file_name: 'Empty' }])).length, 0);
+ const files = await api.collectFiles([{ fid: 'file', file: true, file_name: 'a.txt' }]);
+ assert.equal(files[0].relativeDirectory, '');
+});
+
+test('listing errors do not silently produce a partial result', async () => {
+ const api = setup(async () => ({ code: 31001 }));
+ await assert.rejects(api.collectFiles([{ fid: 'root', file_name: 'Root' }]), /31001/);
+});
+
+test('folder path traversal is rejected', async () => {
+ const api = setup(async () => { throw new Error('should not request'); });
+ await assert.rejects(api.collectFiles([{ fid: 'root', file_name: '..' }]), /名称/);
+});
+
+test('Aria2 directory and headers survive forwarding; ordinary files unchanged', async () => {
+ const start = source.indexOf('async sendLinkToAria2(');
+ const end = source.indexOf('\n\t\t},', start) + '\n\t\t}'.length;
+ const requests = [];
+ const base = { getValue: () => [{ default: true, domain: 'http://localhost', port: '16800', path: '/jsonrpc', dir: '/downloads/', token: '' }], post: async (_url, data) => { requests.push(data); return { result: 'gid' }; } };
+ const api = vm.runInNewContext('({' + source.slice(start, end) + '})', { base });
+ await api.sendLinkToAria2('https://example.org/a', 'a.txt', ['User-Agent:test'], 'Root/Child');
+ assert.equal(requests[0].params[1].dir, '/downloads/Root/Child');
+ assert.equal(requests[0].params[1].out, 'a.txt');
+ assert.equal(requests[0].params[1].header[0], 'User-Agent:test');
+ await api.sendLinkToAria2('https://example.org/a', 'a.txt', []);
+ assert.equal(requests[1].params[1].dir, '/downloads/');
+});
+
+test('getLink keeps directories when download responses arrive in reverse order', async () => {
+ const start = quark.indexOf('async getLink(');
+ const end = quark.indexOf('\n\t\tgetSelectedList()', start);
+ const temp = { page: 'home', mode: 'aria2' };
+ const base = {
+  getValue: () => [{ default: true, dir: '/downloads' }], sleep: async () => {},
+  post: async () => ({ code: 0, data: [
+   { fid: 'b', file_name: 'same.txt', download_url: 'https://example.org/b' },
+   { fid: 'a', file_name: 'same.txt', download_url: 'https://example.org/a' }
+  ] }),
+  generateDOM: () => '', showMainDialog: () => {}
+ };
+ const config = { $quark: { api: { getLink: 'https://example.org/api', ua: { downloadLink: 'test' } }, dom: {} }, base: { dom: { button: { aria2: {} } } } };
+ const api = vm.runInNewContext('({' + quark.slice(start, end) + '})', {
+  base, temp, config, document: { cookie: '' }, location: { host: 'pan.quark.cn' },
+  $doc: { find: () => ({ html() {} }) }
+ });
+ api.getSelectedList = () => [{ fid: 'root', file: false }];
+ api.collectFiles = async () => [
+  { fid: 'a', file: true, relativeDirectory: 'Root/A' },
+  { fid: 'b', file: true, relativeDirectory: 'Root/B' }
+ ];
+ await api.getLink();
+ assert.equal(temp.links[0][0].relativeDirectory, 'Root/B');
+ assert.equal(temp.links[0][1].relativeDirectory, 'Root/A');
+});

--- a/（改）网盘直链下载助手.user.js
+++ b/（改）网盘直链下载助手.user.js
@@ -939,7 +939,7 @@
 		 * @param {Array} [headers] - 自定义请求头参数（可选）
 		 * @returns {Promise<"success"|"fail">} 发送态结果
 		 */
-		async sendLinkToAria2(link, filename, headers) {
+		async sendLinkToAria2(link, filename, headers, relativeDirectory = "") {
 			if (!this.sendLinkToAria2.lock) this.sendLinkToAria2.lock = Promise.resolve();
 			return this.sendLinkToAria2.lock = this.sendLinkToAria2.lock.then(async () => {
 				const list = base.getValue("setting_aria2_rpc");
@@ -952,7 +952,11 @@
 					token: selected.token
 				};
 				const url = `${rpc.domain}:${rpc.port}${rpc.path}`;
-				const dir = (rpc.dir !== null && rpc.dir !== "") ? rpc.dir : undefined;
+				let dir = rpc.dir || undefined;
+				if (relativeDirectory) {
+					if (!dir) return "fail";
+					dir = dir.replace(/[\\/]+$/, "") + "/" + relativeDirectory;
+				}
 				const data = {
 					id: new Date().getTime(),
 					jsonrpc: "2.0",
@@ -3574,7 +3578,7 @@
 						allLink.push(finalink);
 						content.find(".pl-main").append(`<div class="pl-item">
 							<div class="pl-item-name listener-tip" data-size="${size}"><div class="name">${filename}</div><div class="size">${base.sizeFormat(size)}</div></div>
-							<button class="pl-item-link pl-btn-primary pl-btn-default listener-aria2-download" data-filename="${filename}" data-link="${dlink}"><svg class="pl-icon"><use xlink:href="#pl-icon-fa-cloud-arrow-up"/></svg><span>推送链接到 Aria2 下载器</span></button>
+							<button class="pl-item-link pl-btn-primary pl-btn-default listener-aria2-download" data-directory="${encodeURIComponent(v.relativeDirectory || "")}" data-filename="${filename}" data-link="${dlink}"><svg class="pl-icon"><use xlink:href="#pl-icon-fa-cloud-arrow-up"/></svg><span>推送链接到 Aria2 下载器</span></button>
 							<button class="pl-btn-primary pl-btn-info listener-copy listener-tip" data-copy='${finalink}' data-title="Aria2 没启用 RPC？点击复制 aria2c 命令行手动下载"><svg class="pl-icon"><use xlink:href="#pl-icon-fa-copy"/></svg>复制下载命令行</button>
 						</div>`);
 					}
@@ -8210,6 +8214,45 @@ button.downloadSubtitle:disabled {
 	 * @author hmjz100
 	 */
 	const $quark = {
+		async collectFiles(items) {
+			const files = [];
+			const visited = new Set();
+			const walk = async (entries, relativeDirectory) => {
+				for (const item of entries) {
+					if (visited.has(item.fid)) continue;
+					visited.add(item.fid);
+					if (item.file) {
+						files.push({ ...item, relativeDirectory });
+						continue;
+					}
+					// Keep each cloud folder as one local path component.
+					const name = item.file_name;
+					if (!name || name === "." || name === ".." || /[\\/]/.test(name)) {
+						throw new Error("文件夹名称无法用于本地路径");
+					}
+					const directory = relativeDirectory ? relativeDirectory + "/" + name : name;
+					for (let page = 1; ; page++) {
+						const url = new URL(config.$quark.api.getLink);
+						url.pathname = "/1/clouddrive/file/sort";
+						url.searchParams.set("pdir_fid", item.fid);
+						url.searchParams.set("_page", page);
+						url.searchParams.set("_size", "100");
+						url.searchParams.set("_fetch_total", "1");
+						url.searchParams.set("_sort", "file_type:asc,file_name:asc");
+						const res = await base.get(url.href, { "Cookie": String(document.cookie), "User-Agent": config.$quark.api.ua.downloadLink });
+						if (res?.code !== 0 || !Array.isArray(res.data?.list)) {
+							throw new Error("读取文件夹失败，代码：" + (res?.code ?? "unknown"));
+						}
+						const children = res.data.list;
+						await walk(children, directory);
+						if (children.length < 100) break;
+						await base.sleep(300);
+					}
+				}
+			};
+			await walk(items, "");
+			return files;
+		},
 		addPageListener() {
 			$doc.on("click", ".pl-button-save", async function (e) {
 				e.preventDefault();
@@ -8306,7 +8349,7 @@ button.downloadSubtitle:disabled {
 				target.find(".pl-icon").remove();
 				target.find(".pl-loading").remove();
 				target.prepend(base.createLoading());
-				const res = await base.sendLinkToAria2(target.data("link"), target.data("filename"), [`User-Agent:${config.$quark.api.ua.downloadLink}`, `Referer:https://${location.host}/`, `Cookie:${document.cookie}`]);
+				const res = await base.sendLinkToAria2(target.data("link"), target.data("filename"), [`User-Agent:${config.$quark.api.ua.downloadLink}`, `Referer:https://${location.host}/`, `Cookie:${document.cookie}`], decodeURIComponent(target.attr("data-directory") || ""));
 				if (res === "success") {
 					target.removeClass("pl-btn-danger").html("发送成功啦!快去看看吧~").animate({ opacity: "0.5" }, "slow");
 				} else {
@@ -8475,6 +8518,13 @@ button.downloadSubtitle:disabled {
 		async getLink() {
 			let selects = this.getSelectedList();
 			if (selects.length === 0) throw new Error("提示：<br/>请勾选要下载的文件哦~");
+			if (temp.page === "home" && selects.some(item => !item.file)) {
+				if (temp.mode === "aria2" && !base.getValue("setting_aria2_rpc").find(i => i.default)?.dir) {
+					throw new Error("请先在 Aria2 服务设置中填写保存目录，以保留文件夹结构");
+				}
+				selects = await this.collectFiles(selects);
+				if (!selects.length) throw new Error("所选文件夹中没有文件");
+			}
 			if (selects.every(item => !item.file)) throw new Error("提示：<br/>请打开文件夹后再勾选文件~");
 			if (temp.page === "home") {
 				const data = [];
@@ -8505,7 +8555,10 @@ button.downloadSubtitle:disabled {
 
 					// 合并响应数据
 					if (res.data) {
-						data.push(...res.data);
+						data.push(...res.data.map(file => ({
+							...file,
+							relativeDirectory: batch.find(item => item.fid === file.fid)?.relativeDirectory || ""
+						})));
 					}
 					// 更新处理进度
 					proc += batch.length;


### PR DESCRIPTION
## 问题与改动

在夸克「我的网盘」中选择文件夹（包括转存后的文件夹）时，原逻辑会提示「请打开文件夹后再勾选文件」，无法批量下载其子目录。本 PR 递归读取所选目录，以每页 100 条处理分页，再沿用现有批量直链获取和下载流程。

Aria2 推送会将相对目录传给 RPC 的 `dir`，例如 `课程/第一章/a.pdf` 保存到配置目录下的 `课程/第一章/a.pdf`，而不是把各层文件平铺到同一目录。下载接口返回的数据按文件 ID 匹配目录，不依赖返回顺序；请求头和原始文件名继续传递。

## 使用范围

- 支持夸克自己的网盘，包括已转存的文件夹；分享页行为保持原样。
- Aria2 递归推送需先填写下载器机器上的保存目录。Ghost Downloader 4.3.7 不支持 `aria2.getGlobalOption`，因此未依赖该方法查询默认目录。
- 其他下载方式可以获取递归文件列表，但本次仅对 Aria2 推送保留目录结构。空目录不会单独创建。
- 不改版本号，目标分支为 `dev`。

## 验证

- `node --test tests/quark-recursive.test.cjs`：6 项通过，覆盖多层目录、分页、重复选择、不同目录同名文件、空目录、读取失败、路径校验、RPC 参数及直链返回乱序。
- `node --check`：通过。
- ESLint：0 errors，保留上游已有的 2 条 unused-vars warnings。
- Ghost Downloader 4.3.7 实机 RPC 测试：嵌套目录文件成功创建，内容一致。
- 使用者已安装修改后的脚本，在真实夸克账号中测试并确认可用；未提供具体目录深度和文件数量，分页边界由自动化测试覆盖。

目录接口参数参考 OpenList 的公开实现：https://github.com/OpenListTeam/OpenList/blob/main/drivers/quark_uc/util.go
